### PR TITLE
fix: include worker files in pkg build

### DIFF
--- a/exeBuild.config.js
+++ b/exeBuild.config.js
@@ -17,6 +17,8 @@ module.exports = {
             'node_modules/pdfkit/js/data/Helvetica.afm',
             'dist/mcdu/**/*',
             'dist/assets/**/*',
+            'dist/terrain/manager/maploader.js',
+            'dist/terrain/utils/**/*.js',
         ],
         outputPath: 'build',
     },


### PR DESCRIPTION
As the node workers are not explicitly imported, they are probably not automatically packaged by pkg resulting in a simbridge crash. I've added them as a part of the config and a local pkg build seemed promising.