### PR TITLE
fix(mcdu): add side to remote mcdu events

### DIFF
--- a/apps/mcdu/src/components/McduButtons.jsx
+++ b/apps/mcdu/src/components/McduButtons.jsx
@@ -27,9 +27,9 @@ const Button = ({ soundEnabled, name }) => {
         if (soundEnabled) {
             new Audio(soundFile).play();
         }
-        socket.sendMessage(`event:${name}`);
+        socket.sendMessage(`event:left:${name}`);
         timeout.current = setTimeout(() => {
-            socket.sendMessage(`event:${name}_Held`);
+            socket.sendMessage(`event:left:${name}_Held`);
         }, buttonHeldTime);
     }
 


### PR DESCRIPTION
Needs https://github.com/flybywiresim/a32nx/pull/7370. Simbridge can work fine even after that is merged without this PR, as 7370 is backwards compatible for this side.