### PR TITLE
Removed linter checking line ending

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,7 +36,8 @@
 		"no-empty-function": "off",
 
 		// Annoying shit
-		"linebreak-style": ["error", "unix"],
+		"linebreak-style": "off",
+		// "linebreak-style": ["error", "unix"],
 		"no-await-in-loop":"off",
 		"strict": "off",
 		"jsx-a11y/click-events-have-key-events": "off",

--- a/apps/server/src/utilities/utilities.controller.ts
+++ b/apps/server/src/utilities/utilities.controller.ts
@@ -19,7 +19,7 @@ export class UtiliyController {
         @Query('pagenumber', ParseIntPipe) pagenumber: number,
         @Response({ passthrough: true }) res,
     ): Promise<StreamableFile> {
-        const convertedPdfFile = await this.fileService.getConvertedPdfFile(`${filename}.pdf`, pagenumber);
+        const convertedPdfFile = await this.fileService.getConvertedPdfFile(`${filename}`, pagenumber);
 
         res.set({
             'Content-Type': 'image/png',
@@ -46,7 +46,7 @@ export class UtiliyController {
         type: Number,
     })
     async getNumberOfPages(@Query('filename') filename: string): Promise<number> {
-        return this.fileService.getNumberOfPdfPages(`${filename}.pdf`);
+        return this.fileService.getNumberOfPdfPages(`${filename}`);
     }
 
     @Get('image')


### PR DESCRIPTION
# Change
 
The utilities controller added .pdf to read the actual file from filesystem. As the API returns the full filename adding an extra .pdf doubled the extension and the file could not be found.

This PR removes the extra ".pdf" being added to the filename.

Discord: Cdr_Maverick#6475
