### PR TITLE
fix: Fix shutdown handling

### DIFF
--- a/apps/server/src/health/health.controller.ts
+++ b/apps/server/src/health/health.controller.ts
@@ -6,6 +6,7 @@ import {
     HttpHealthIndicator,
     HealthCheck,
 } from '@nestjs/terminus';
+import { ShutDownService } from '../utilities/shutdown.service';
 import serverConfig from '../config/server.config';
 
 @ApiTags('HEALTH')
@@ -15,6 +16,7 @@ export class HealthController {
     @Inject(serverConfig.KEY) private serverConf: ConfigType<typeof serverConfig>,
     private health: HealthCheckService,
     private http: HttpHealthIndicator,
+    private shutdownService: ShutDownService,
     ) {}
 
     private readonly logger = new Logger(HealthController.name);
@@ -37,6 +39,6 @@ export class HealthController {
     })
     killApp() {
         this.logger.log('Server shutting down via endpoint call');
-        process.exit();
+        this.shutdownService.shutdown();
     }
 }

--- a/apps/server/src/health/health.module.ts
+++ b/apps/server/src/health/health.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { HttpModule } from '@nestjs/axios';
 import { HealthController } from './health.controller';
+import { UtilitiesModule } from '../utilities/utilities.module';
 
-@Module({ imports: [HttpModule, TerminusModule], controllers: [HealthController] })
+@Module({ imports: [HttpModule, TerminusModule, UtilitiesModule], controllers: [HealthController] })
 export class HealthModule {}

--- a/apps/server/src/utilities/shutdown.service.ts
+++ b/apps/server/src/utilities/shutdown.service.ts
@@ -1,15 +1,24 @@
-import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common';
-import { SysTrayService } from './systray.service';
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { Subject } from 'rxjs';
 
 @Injectable()
-export class ShutDownService implements OnApplicationShutdown {
-  private readonly logger = new Logger(ShutDownService.name);
+export class ShutDownService implements OnModuleDestroy {
+    private readonly logger = new Logger(ShutDownService.name);
 
-  constructor(private systrayService: SysTrayService) {}
+    private shutdownListener$: Subject<void> = new Subject();
 
-  onApplicationShutdown(signal: string) {
-      this.logger.log(`Application shutting down with signal: ${signal}`);
-      // Handle all graceful kill events
-      this.systrayService.kill();
-  }
+    // Your hook will be executed
+    onModuleDestroy() {
+        this.logger.log('ShutDown Service being destroyed');
+    }
+
+    // Subscribe to the shutdown in your main.ts
+    subscribeToShutdown(shutdownFn: () => void): void {
+        this.shutdownListener$.subscribe(() => shutdownFn());
+    }
+
+    // Emit the shutdown event
+    shutdown() {
+        this.shutdownListener$.next();
+    }
 }

--- a/apps/server/src/utilities/utilities.module.ts
+++ b/apps/server/src/utilities/utilities.module.ts
@@ -2,12 +2,12 @@ import { Module } from '@nestjs/common';
 import { UtiliyController } from './utilities.controller';
 import { FileService } from './file.service';
 import { PrinterService } from './printer.service';
-import { ShutDownService } from './shutdown.service';
 import { SysTrayService } from './systray.service';
+import { ShutDownService } from './shutdown.service';
 
 @Module({
     controllers: [UtiliyController],
-    providers: [FileService, PrinterService, ShutDownService, SysTrayService],
-    exports: [FileService, PrinterService],
+    providers: [FileService, PrinterService, SysTrayService, ShutDownService],
+    exports: [FileService, PrinterService, ShutDownService],
 })
 export class UtilitiesModule {}


### PR DESCRIPTION
Fixes #15 

- Migrate systems tray to it's own constructor rather than started
by the app
- WIP finding a way to emit shutdown event rather than process.exit

using https://stackoverflow.com/a/57151478 as a solution