### PR TITLE
fix: Reading files in folders filters for files

### DIFF
--- a/apps/server/src/utilities/utilities.controller.ts
+++ b/apps/server/src/utilities/utilities.controller.ts
@@ -5,7 +5,7 @@ import { FileService } from './file.service';
 
 @ApiTags('UTILITIES')
 @Controller('api/v1/utility')
-export class UtiliyController {
+export class UtilityController {
     constructor(private fileService: FileService) {}
 
     @Get('pdf')

--- a/apps/server/src/utilities/utilities.module.ts
+++ b/apps/server/src/utilities/utilities.module.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common';
-import { UtiliyController } from './utilities.controller';
+import { UtilityController } from './utilities.controller';
 import { FileService } from './file.service';
 import { PrinterService } from './printer.service';
 import { ShutDownService } from './shutdown.service';
 import { SysTrayService } from './systray.service';
 
 @Module({
-    controllers: [UtiliyController],
+    controllers: [UtilityController],
     providers: [FileService, PrinterService, ShutDownService, SysTrayService],
     exports: [FileService, PrinterService],
 })


### PR DESCRIPTION
FileService reads on folder were reading directories as files. 
This PR fixes this by filtering for files.

Also fixes a Typo in a classname

**Needs testing with CoRoutes and Terrain before merging.**

Discord: Cdr_Maverick#6475