### PR TITLE
feat: use the private IP instead of `localhost` in "Open MCDU"

### DIFF
--- a/apps/server/src/interfaces/mcdu.gateway.ts
+++ b/apps/server/src/interfaces/mcdu.gateway.ts
@@ -2,7 +2,7 @@ import { Inject, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import { OnGatewayConnection, OnGatewayInit, WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 import { Server, WebSocket } from 'ws';
-import { address } from 'ip';
+import { getPrivateIp } from '../utilities/ip';
 import { PrinterService } from '../utilities/printer.service';
 import serverConfig from '../config/server.config';
 
@@ -23,7 +23,7 @@ export class McduGateway implements OnGatewayInit, OnGatewayConnection {
     afterInit(server: Server) {
         this.server = server;
         this.logger.log('Remote MCDU websocket initialised');
-        this.logger.log(`Initialised on http://${address()}:${this.serverConf.port}${server.path}`);
+        this.logger.log(`Initialised on http://${getPrivateIp()}:${this.serverConf.port}${server.path}`);
     }
 
     handleConnection(client: WebSocket) {

--- a/apps/server/src/interfaces/mcdu.gateway.ts
+++ b/apps/server/src/interfaces/mcdu.gateway.ts
@@ -20,10 +20,10 @@ export class McduGateway implements OnGatewayInit, OnGatewayConnection {
 
     @WebSocketServer() server: Server
 
-    afterInit(server: Server) {
+    async afterInit(server: Server) {
         this.server = server;
         this.logger.log('Remote MCDU websocket initialised');
-        this.logger.log(`Initialised on http://${getPrivateIp()}:${this.serverConf.port}${server.path}`);
+        this.logger.log(`Initialised on http://${await getPrivateIp()}:${this.serverConf.port}${server.path}`);
     }
 
     handleConnection(client: WebSocket) {

--- a/apps/server/src/interfaces/mcdu.gateway.ts
+++ b/apps/server/src/interfaces/mcdu.gateway.ts
@@ -2,7 +2,7 @@ import { Inject, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import { OnGatewayConnection, OnGatewayInit, WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 import { Server, WebSocket } from 'ws';
-import { getPrivateIp } from '../utilities/ip';
+import { getLocalIp } from '../utilities/ip';
 import { PrinterService } from '../utilities/printer.service';
 import serverConfig from '../config/server.config';
 
@@ -23,7 +23,7 @@ export class McduGateway implements OnGatewayInit, OnGatewayConnection {
     async afterInit(server: Server) {
         this.server = server;
         this.logger.log('Remote MCDU websocket initialised');
-        this.logger.log(`Initialised on http://${await getPrivateIp()}:${this.serverConf.port}${server.path}`);
+        this.logger.log(`Initialised on http://${await getLocalIp()}:${this.serverConf.port}${server.path}`);
     }
 
     handleConnection(client: WebSocket) {

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -58,7 +58,7 @@ async function bootstrap() {
     await app.listen(port);
 
     const logger = app.get(WINSTON_MODULE_NEST_PROVIDER);
-    logger.log(`FlyByWire SimBridge started on: http://${getPrivateIp()}:${port}`, 'NestApplication');
+    logger.log(`FlyByWire SimBridge started on: http://${await getPrivateIp()}:${port}`, 'NestApplication');
 
     app.select(UtilitiesModule).get(SysTrayService).init(isConsoleHidden, port);
 

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -8,7 +8,7 @@ import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { platform } from 'os';
 import { hideConsole } from 'node-hide-console-window';
-import { getPrivateIp } from './utilities/ip';
+import { getLocalIp } from './utilities/ip';
 import { UtilitiesModule } from './utilities/utilities.module';
 import { SysTrayService } from './utilities/systray.service';
 import { AppModule } from './app.module';
@@ -58,7 +58,7 @@ async function bootstrap() {
     await app.listen(port);
 
     const logger = app.get(WINSTON_MODULE_NEST_PROVIDER);
-    logger.log(`FlyByWire SimBridge started on: http://${await getPrivateIp()}:${port}`, 'NestApplication');
+    logger.log(`FlyByWire SimBridge started on: http://${await getLocalIp()}:${port}`, 'NestApplication');
 
     app.select(UtilitiesModule).get(SysTrayService).init(isConsoleHidden, port);
 

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -6,9 +6,9 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { WsAdapter } from '@nestjs/platform-ws';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
-import { address } from 'ip';
 import { platform } from 'os';
 import { hideConsole } from 'node-hide-console-window';
+import { getPrivateIp } from './utilities/ip';
 import { UtilitiesModule } from './utilities/utilities.module';
 import { SysTrayService } from './utilities/systray.service';
 import { AppModule } from './app.module';
@@ -58,7 +58,7 @@ async function bootstrap() {
     await app.listen(port);
 
     const logger = app.get(WINSTON_MODULE_NEST_PROVIDER);
-    logger.log(`FlyByWire SimBridge started on: http://${address()}:${port}`, 'NestApplication');
+    logger.log(`FlyByWire SimBridge started on: http://${getPrivateIp()}:${port}`, 'NestApplication');
 
     app.select(UtilitiesModule).get(SysTrayService).init(isConsoleHidden, port);
 

--- a/apps/server/src/utilities/ip.ts
+++ b/apps/server/src/utilities/ip.ts
@@ -1,7 +1,10 @@
 import { networkInterfaces } from 'os';
 
 /**
- * Returns the private (usually 192.168.x.x) IP of the computer.
+ * Returns the private IP (usually 192.168.x.x) of the computer, or `null` if none is found.
+ *
+ * There's no reliable way to get the private/local IP of the computer, so a heuristic is used
+ * which is not perfect and may return false positives for unusual network configurations.
  */
 export function getPrivateIp() {
     for (const interfaces of Object.values(networkInterfaces())) {
@@ -12,10 +15,9 @@ export function getPrivateIp() {
 
             const parts = iface.address.split('.');
 
-            // Determine whether the given IPv4 address is a part of a private netowrk.
-            // Source: https://en.wikipedia.org/wiki/Private_network#Private_IPv4_addresses
+            // Heuristic based on private IPv4 address ranges (https://en.wikipedia.org/wiki/Private_network).
+            // 172.16.0.0/12 is excluded because it seems to be often used by services such as Docker or Hyper-V.
             if (parts[0] === '10' // 10.0.0.0/8
-                || (parts[0] === '172' && parts[1] >= '16' && parts[1] <= '31') // 172.16.0.0/12
                 || (parts[0] === '192' && parts[1] === '168') // 192.168.0.0/16
             ) {
                 return iface.address;

--- a/apps/server/src/utilities/ip.ts
+++ b/apps/server/src/utilities/ip.ts
@@ -1,29 +1,42 @@
 import { networkInterfaces } from 'os';
+import { AddressInfo, createConnection } from 'net';
 
 /**
- * Returns the private IP (usually 192.168.x.x) of the computer, or `null` if none is found.
- *
- * There's no reliable way to get the private/local IP of the computer, so a heuristic is used
- * which is not perfect and may return false positives for unusual network configurations.
+ * Returns the private IP (usually 192.168.x.x) of the computer, or `localhost` if none is found.
  */
-export function getPrivateIp() {
-    for (const interfaces of Object.values(networkInterfaces())) {
-        for (const iface of interfaces) {
-            if (iface.family !== 'IPv4') {
-                continue;
+export async function getPrivateIp() {
+    return new Promise<string>((resolve) => {
+        // It's hard to reliably find the private IP so we try using 2 different methods.
+        // First, we try to connect to api.flybywiresim.com:443 and see if we can extract the IP
+        // from the socket connection.
+        const conn = createConnection({ host: 'api.flybywiresim.com', port: 443, timeout: 1000 });
+
+        conn.on('connect', () => {
+            resolve((conn.address() as AddressInfo).address);
+        });
+
+        conn.on('error', () => {
+            conn.destroy();
+
+            // If the connection fails for whatever reason, we query the list of network interfaces
+            // and try to get the IP from there.
+            for (const interfaces of Object.values(networkInterfaces())) {
+                for (const iface of interfaces) {
+                    if (iface.family !== 'IPv4') {
+                        continue;
+                    }
+
+                    const parts = iface.address.split('.');
+
+                    if (parts[0] === '10' // 10.0.0.0/8
+                        || (parts[0] === '192' && parts[1] === '168') // 192.168.0.0/16
+                    ) {
+                        resolve(iface.address);
+                    }
+                }
             }
 
-            const parts = iface.address.split('.');
-
-            // Heuristic based on private IPv4 address ranges (https://en.wikipedia.org/wiki/Private_network).
-            // 172.16.0.0/12 is excluded because it seems to be often used by services such as Docker or Hyper-V.
-            if (parts[0] === '10' // 10.0.0.0/8
-                || (parts[0] === '192' && parts[1] === '168') // 192.168.0.0/16
-            ) {
-                return iface.address;
-            }
-        }
-    }
-
-    return null;
+            resolve('localhost');
+        });
+    });
 }

--- a/apps/server/src/utilities/ip.ts
+++ b/apps/server/src/utilities/ip.ts
@@ -2,11 +2,11 @@ import { networkInterfaces } from 'os';
 import { AddressInfo, createConnection } from 'net';
 
 /**
- * Returns the private IP (usually 192.168.x.x) of the computer, or `localhost` if none is found.
+ * Returns the local IP (usually 192.168.x.x) of the computer, or `localhost` if none is found.
  */
-export async function getPrivateIp() {
+export async function getLocalIp() {
     return new Promise<string>((resolve) => {
-        // It's hard to reliably find the private IP so we try using 2 different methods.
+        // It's hard to reliably find the local IP so we try using 2 different methods.
         // First, we try to connect to api.flybywiresim.com:443 and see if we can extract the IP
         // from the socket connection.
         const conn = createConnection({ host: 'api.flybywiresim.com', port: 443, timeout: 1000 });

--- a/apps/server/src/utilities/ip.ts
+++ b/apps/server/src/utilities/ip.ts
@@ -1,0 +1,27 @@
+import { networkInterfaces } from 'os';
+
+/**
+ * Returns the private (usually 192.168.x.x) IP of the computer.
+ */
+export function getPrivateIp() {
+    for (const interfaces of Object.values(networkInterfaces())) {
+        for (const iface of interfaces) {
+            if (iface.family !== 'IPv4') {
+                continue;
+            }
+
+            const parts = iface.address.split('.');
+
+            // Determine whether the given IPv4 address is a part of a private netowrk.
+            // Source: https://en.wikipedia.org/wiki/Private_network#Private_IPv4_addresses
+            if (parts[0] === '10' // 10.0.0.0/8
+                || (parts[0] === '172' && parts[1] >= '16' && parts[1] <= '31') // 172.16.0.0/12
+                || (parts[0] === '192' && parts[1] === '168') // 192.168.0.0/16
+            ) {
+                return iface.address;
+            }
+        }
+    }
+
+    return null;
+}

--- a/apps/server/src/utilities/systray.service.ts
+++ b/apps/server/src/utilities/systray.service.ts
@@ -1,8 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { hideConsole, showConsole } from 'node-hide-console-window';
 import open = require('open');
-import { join } from 'path';
 import SysTray, { MenuItem } from 'systray2';
+import { join } from 'path';
+import { getPrivateIp } from './ip';
 
 interface MenuItemClickable extends MenuItem {
     click?: () => void
@@ -31,7 +32,7 @@ export class SysTrayService {
               tooltip: 'Open the MCDU remote display with your default browser',
               enabled: true,
               click: () => {
-                  open(`http://localhost:${port}/interfaces/mcdu`);
+                  open(`http://${getPrivateIp()}:${port}/interfaces/mcdu`);
               },
           }],
       };

--- a/apps/server/src/utilities/systray.service.ts
+++ b/apps/server/src/utilities/systray.service.ts
@@ -39,8 +39,8 @@ export class SysTrayService {
               title: 'Open MCDU (with local IP)',
               tooltip: 'Open the MCDU remote display with your default browser, using your local IP',
               enabled: true,
-              click: () => {
-                  open(`http://${getPrivateIp()}:${port}/interfaces/mcdu`);
+              click: async () => {
+                  open(`http://${await getPrivateIp()}:${port}/interfaces/mcdu`);
               },
           }],
       };

--- a/apps/server/src/utilities/systray.service.ts
+++ b/apps/server/src/utilities/systray.service.ts
@@ -6,7 +6,8 @@ import { join } from 'path';
 import { getPrivateIp } from './ip';
 
 interface MenuItemClickable extends MenuItem {
-    click?: () => void
+    click?: () => void;
+    items?: MenuItemClickable[];
 }
 
 @Injectable()
@@ -24,7 +25,7 @@ export class SysTrayService {
           hidden = !hidden;
       };
 
-      const remoteDisplayItem = {
+      const remoteDisplayItem: MenuItemClickable = {
           title: 'Remote Displays',
           tooltip: 'Open remote displays',
           items: [{
@@ -37,7 +38,7 @@ export class SysTrayService {
           }],
       };
 
-      const resourcesFolderItem = {
+      const resourcesFolderItem: MenuItemClickable = {
           title: 'Open Resources Folder',
           tooltip: 'Open resource folder in your file explorer',
           enabled: true,
@@ -46,7 +47,7 @@ export class SysTrayService {
           },
       };
 
-      const exitItem : MenuItemClickable = {
+      const exitItem: MenuItemClickable = {
           title: 'Exit',
           tooltip: 'Kill the server',
           checked: false,
@@ -57,7 +58,7 @@ export class SysTrayService {
           },
       };
 
-      const consoleVisibleItem : MenuItemClickable = {
+      const consoleVisibleItem: MenuItemClickable = {
           title: 'Show/Hide',
           tooltip: 'Change console visibility',
           checked: false,

--- a/apps/server/src/utilities/systray.service.ts
+++ b/apps/server/src/utilities/systray.service.ts
@@ -30,7 +30,14 @@ export class SysTrayService {
           tooltip: 'Open remote displays',
           items: [{
               title: 'Open MCDU',
-              tooltip: 'Open the MCDU remote display with your default browser',
+              tooltip: 'Open the MCDU remote display with your default browser, using localhost',
+              enabled: true,
+              click: () => {
+                  open(`http://localhost:${port}/interfaces/mcdu`);
+              },
+          }, {
+              title: 'Open MCDU (with local IP)',
+              tooltip: 'Open the MCDU remote display with your default browser, using your local IP',
               enabled: true,
               click: () => {
                   open(`http://${getPrivateIp()}:${port}/interfaces/mcdu`);

--- a/apps/server/src/utilities/systray.service.ts
+++ b/apps/server/src/utilities/systray.service.ts
@@ -3,7 +3,7 @@ import { hideConsole, showConsole } from 'node-hide-console-window';
 import open = require('open');
 import SysTray, { MenuItem } from 'systray2';
 import { join } from 'path';
-import { getPrivateIp } from './ip';
+import { getLocalIp } from './ip';
 
 interface MenuItemClickable extends MenuItem {
     click?: () => void;
@@ -30,17 +30,10 @@ export class SysTrayService {
           tooltip: 'Open remote displays',
           items: [{
               title: 'Open MCDU',
-              tooltip: 'Open the MCDU remote display with your default browser, using localhost',
-              enabled: true,
-              click: () => {
-                  open(`http://localhost:${port}/interfaces/mcdu`);
-              },
-          }, {
-              title: 'Open MCDU (with local IP)',
               tooltip: 'Open the MCDU remote display with your default browser, using your local IP',
               enabled: true,
               click: async () => {
-                  open(`http://${await getPrivateIp()}:${port}/interfaces/mcdu`);
+                  open(`http://${await getLocalIp()}:${port}/interfaces/mcdu`);
               },
           }],
       };

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
 				"class-transformer": "^0.4.0",
 				"class-validator": "^0.13.2",
 				"copyfiles": "^2.4.1",
-				"ip": "^1.1.5",
 				"mime-types": "^2.1.34",
 				"nest-winston": "^1.6.2",
 				"node-hide-console-window": "^2.1.1",
@@ -61,7 +60,7 @@
 				"@babel/preset-react": "^7.16.7",
 				"@babel/runtime": "^7.17.2",
 				"@flybywiresim/eslint-config": "^0.2.3",
-				"@flybywiresim/fragmenter": "^0.6.1",
+				"@flybywiresim/fragmenter": "^0.7.1",
 				"@nestjs/cli": "^8.0.0",
 				"@nestjs/schematics": "^8.0.0",
 				"@nestjs/testing": "^8.0.0",
@@ -2328,10 +2327,16 @@
 			}
 		},
 		"node_modules/@flybywiresim/fragmenter": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.6.1.tgz",
-			"integrity": "sha512-HX8J20aMwJLJ5g2mycddXn9/UlzDMQj51KJGd9vPcAzIb298a0VTnnJbzzmiJEE+7uylhhonJGNVjYYOmrGEnA==",
-			"dev": true
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.7.1.tgz",
+			"integrity": "sha512-jwbkfHhIfkBral8dtMUpDDDrZs8vmF9gB5oF40GfMo1nM3mWpyHP3bh581//Am/yJ2noNp3djywuUL/nnkiY7g==",
+			"dev": true,
+			"dependencies": {
+				"axios": "^0.27.2",
+				"split-file": "^2.3.0",
+				"url-join": "^4.0.1",
+				"zip-lib": "^0.7.3"
+			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.5.0",
@@ -5347,6 +5352,12 @@
 				"safe-buffer": "~5.2.0"
 			}
 		},
+		"node_modules/bluebird": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+			"dev": true
+		},
 		"node_modules/body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -5523,6 +5534,15 @@
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
+			}
+		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true,
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/buffer-equal": {
@@ -8300,6 +8320,15 @@
 				"bser": "2.1.1"
 			}
 		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"dev": true,
+			"dependencies": {
+				"pend": "~1.2.0"
+			}
+		},
 		"node_modules/fecha": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
@@ -9399,11 +9428,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/ip": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
 		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
@@ -12414,6 +12438,12 @@
 				"npm": ">=6"
 			}
 		},
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"dev": true
+		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -14666,6 +14696,18 @@
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
 			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
 		},
+		"node_modules/split-file": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/split-file/-/split-file-2.3.0.tgz",
+			"integrity": "sha512-dc/0SDKvjtSjUI999vkclWQAk5xhD86pKEWWL2ULR6WrHI9/euIEMG/JSUbwbNW8IC+gYLJqynSGHwlOVmSwGA==",
+			"dev": true,
+			"dependencies": {
+				"bluebird": "^3.7.2"
+			},
+			"bin": {
+				"split-file": "split-file-cli.js"
+			}
+		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -16242,6 +16284,12 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/url-join": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+			"dev": true
+		},
 		"node_modules/url-loader": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
@@ -17078,6 +17126,25 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"dev": true,
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
+		},
+		"node_modules/yazl": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+			"integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+			"dev": true,
+			"dependencies": {
+				"buffer-crc32": "~0.2.3"
+			}
+		},
 		"node_modules/yn": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -17085,6 +17152,19 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/zip-lib": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/zip-lib/-/zip-lib-0.7.3.tgz",
+			"integrity": "sha512-hp40KYzTJvoaCRr2t6hztlPnVmHYqDUDiIn0hlfAFwVBs3/jwkLy8aZ7NVGHECeWH2Tv8WPwWyR6QuWYarIjJQ==",
+			"dev": true,
+			"dependencies": {
+				"yauzl": "^2.10.0",
+				"yazl": "^2.5.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		}
 	},
@@ -18660,10 +18740,16 @@
 			"requires": {}
 		},
 		"@flybywiresim/fragmenter": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.6.1.tgz",
-			"integrity": "sha512-HX8J20aMwJLJ5g2mycddXn9/UlzDMQj51KJGd9vPcAzIb298a0VTnnJbzzmiJEE+7uylhhonJGNVjYYOmrGEnA==",
-			"dev": true
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@flybywiresim/fragmenter/-/fragmenter-0.7.1.tgz",
+			"integrity": "sha512-jwbkfHhIfkBral8dtMUpDDDrZs8vmF9gB5oF40GfMo1nM3mWpyHP3bh581//Am/yJ2noNp3djywuUL/nnkiY7g==",
+			"dev": true,
+			"requires": {
+				"axios": "^0.27.2",
+				"split-file": "^2.3.0",
+				"url-join": "^4.0.1",
+				"zip-lib": "^0.7.3"
+			}
 		},
 		"@humanwhocodes/config-array": {
 			"version": "0.5.0",
@@ -20964,6 +21050,12 @@
 				}
 			}
 		},
+		"bluebird": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+			"dev": true
+		},
 		"body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -21109,6 +21201,12 @@
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
 			}
+		},
+		"buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true
 		},
 		"buffer-equal": {
 			"version": "0.0.1",
@@ -23298,6 +23396,15 @@
 				"bser": "2.1.1"
 			}
 		},
+		"fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"dev": true,
+			"requires": {
+				"pend": "~1.2.0"
+			}
+		},
 		"fecha": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
@@ -24124,11 +24231,6 @@
 				"from2": "^2.3.0",
 				"p-is-promise": "^3.0.0"
 			}
-		},
-		"ip": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
 		},
 		"ipaddr.js": {
 			"version": "1.9.1",
@@ -26397,6 +26499,12 @@
 			"integrity": "sha512-mMVGKfeI6VOLqMOCiLaU4KNd4cgk8YcQVvJ07YIA6iujM4uKOgmDsmIp1qsKWEHt8cMoizVGFniQUrtN6pjtJA==",
 			"dev": true
 		},
+		"pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"dev": true
+		},
 		"picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -28044,6 +28152,15 @@
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
 			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
 		},
+		"split-file": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/split-file/-/split-file-2.3.0.tgz",
+			"integrity": "sha512-dc/0SDKvjtSjUI999vkclWQAk5xhD86pKEWWL2ULR6WrHI9/euIEMG/JSUbwbNW8IC+gYLJqynSGHwlOVmSwGA==",
+			"dev": true,
+			"requires": {
+				"bluebird": "^3.7.2"
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -29226,6 +29343,12 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"url-join": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+			"dev": true
+		},
 		"url-loader": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.1.tgz",
@@ -29823,11 +29946,40 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
 		},
+		"yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"dev": true,
+			"requires": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
+		},
+		"yazl": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+			"integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+			"dev": true,
+			"requires": {
+				"buffer-crc32": "~0.2.3"
+			}
+		},
 		"yn": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
 			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
 			"dev": true
+		},
+		"zip-lib": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/zip-lib/-/zip-lib-0.7.3.tgz",
+			"integrity": "sha512-hp40KYzTJvoaCRr2t6hztlPnVmHYqDUDiIn0hlfAFwVBs3/jwkLy8aZ7NVGHECeWH2Tv8WPwWyR6QuWYarIjJQ==",
+			"dev": true,
+			"requires": {
+				"yauzl": "^2.10.0",
+				"yazl": "^2.5.1"
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
 		"class-transformer": "^0.4.0",
 		"class-validator": "^0.13.2",
 		"copyfiles": "^2.4.1",
-		"ip": "^1.1.5",
 		"mime-types": "^2.1.34",
 		"nest-winston": "^1.6.2",
 		"node-hide-console-window": "^2.1.1",


### PR DESCRIPTION
By using the computer's private IP instead of `localhost`, it is much easier to find the remote MCDU URL and copy it to another device. It is no longer required to go through the entire ritual of finding your computer's private IP, which some folks found confusing.

Getting the computer's private IP seems to be a hard problem, but the way I have implemented it is reliable as long as the user can access `api.flybywire.com:443` (TCP). If they cannot, a heuristic fallback is used which _may_ return a false positive with certain, unusual network configurations. 

In the process I also removed the `ip` dependency and replaced the functionality we need from it by a, small, custom function. It's an unnecessary and unmaintained dependency and [the logic for getting the private IP is inverted](https://github.com/indutny/node-ip/blob/main/lib/ip.js#L398-L399) (`address('private')` returns the public IP). Additionally, not supplying either `public` or `private` as an argument meant that it would use the first network adapter's IP which in my case was not my actual private IP (it was some random Hamachi adapter's IP).

This is the first of (hopefully) two quality of life PRs based on painpoints pointed out at FSweekend.