### PR TITLE
fix: log spam sometimes caused by mDNS

### DIFF
--- a/apps/server/src/utilities/file.service.ts
+++ b/apps/server/src/utilities/file.service.ts
@@ -79,7 +79,7 @@ export class FileService {
             const file = await readFile(path);
             return file;
         } catch (err) {
-            const message = `Error retrieving file: ${fileName} in folder:${directory}`;
+            const message = `Error retrieving file: ${fileName} in folder: ${directory}`;
             this.logger.error(message, err);
             throw new HttpException(message, HttpStatus.NOT_FOUND);
         }

--- a/apps/server/src/utilities/network.service.ts
+++ b/apps/server/src/utilities/network.service.ts
@@ -38,7 +38,13 @@ export class NetworkService implements OnApplicationShutdown {
         });
 
         this.mDNSServer.on('warning', (error) => {
-            this.logger.warn(`mDNS server warning: ${error.message}`);
+            if (/Cannot decode name \(.+\)/.test(error.message)) {
+                // Ignore this error as it usually comes from irrelevant malformed mDNS packets (particularly from Internet connected radios)
+                // and needlessly spams the log
+                return;
+            }
+
+            this.logger.warn(`mDNS server error: ${error.message}`);
         });
 
         this.mDNSServer.on('ready', () => {


### PR DESCRIPTION
A user reported the SimBridge log being spammed by mDNS errors which I tracked down to an Internet-connected radio sending malformed mDNS packets that were completely irrelevant to SimBridge. I'm not sure if the packets were actually malformed or if the device was simply misusing port 5353, but this catches and ignores such errors. 
This is not the perfect fix, but if we are getting malformed packets from a browser, something has already gone horribly wrong. 