### PR TITLE
added setup.sh and readme updates for working build and run

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,24 @@ This repo contains the source code to SimBridge
 Please make sure you have:
 
 NodeJS 16 - [Homepage](https://nodejs.org/en/)
+ - Install the latest node/npm,
+ - Install [NVM for windows](https://github.com/coreybutler/nvm-windows) or [nvm for *nix](https://github.com/nvm-sh/nvm)
+ - $ nvm install v16.20.0
+ - $ nvm use 16.20.0
 
+
+First time
 ```bash
-# Install all dependencies
-$ npm install
+$ ./setup.sh
+```
 
-# Build all packages
-$ npm run build
+then every time to want to run it
+```bash
 
-# Start server, to use interfaces you need to build them beforehand
 $ npm run start
+
+#or if you want to use magic hot reloading upon save
+$ npm run start:dev
 
 # Wipe build/ and dist/ folders, build all packages, package to exe and copy dependencies/resources to build folder
 $ npm run build:exec

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,13 @@
+
+# Install all dependencies
+npm install
+#copy dependancies to places
+npm run copy:deps
+
+# move the `build/resources` folder to the project root folder (overwrite everything)
+cp -rf ./build/resources ./
+# move the `build/terrain` folder to the project root folder
+cp -rf ./build/terrain ./
+
+#copy up simconnect dll
+cp build/Simconnect.dll ./


### PR DESCRIPTION
I had some issues getting the build working using readme, 
@Saschl helped identify the extra steps needed, This change updates the readme to point to a sh file that can be run to do all the setup steps. this in itself is simple enough and can be run command by command manually as needed.
I also added further instructions on how to install and use an older Node version.