### PR TITLE
fix: stop sending terrain on nd data if the sim stopped or is paused

### DIFF
--- a/apps/server/src/terrain/communication/simconnect.ts
+++ b/apps/server/src/terrain/communication/simconnect.ts
@@ -10,13 +10,21 @@ import {
     ClientDataRequestMessage,
     ClientDataPeriod,
     ClientDataRequest,
+    SystemEvent,
+    SystemEventType,
+    SystemEventMessage,
+    SystemEventSim,
+    SystemEventPause,
+    SystemEventPauseType,
 } from '@flybywiresim/msfs-nodejs';
 import { Logger } from '../processing/logging/logger';
 import { NavigationDisplayData } from '../processing/navigationdisplaydata';
 import { AircraftStatus, PositionData, TerrainRenderingMode } from './types';
 
 export type UpdateCallbacks = {
-    connectionLost: () => void;
+    reset: () => void;
+    paused: () => void;
+    unpaused: () => void;
     positionUpdate: (data: PositionData) => void;
     aircraftStatusUpdate: (data: AircraftStatus) => void;
 }
@@ -39,17 +47,26 @@ const enum DataDefinitionId {
     NavigationDisplayFrameAreaRight = 4,
 }
 
+const enum SystemEventId {
+    SimulatorState = 0,
+    PauseState = 1,
+}
+
 const EnhancedGpwcAircraftStatusByteCount = 46;
 const NavigationDisplayThresholdByteCount = 14;
 
 export class SimConnect {
     private callbacks: UpdateCallbacks = {
-        connectionLost: null,
+        reset: null,
+        paused: null,
+        unpaused: null,
         positionUpdate: null,
         aircraftStatusUpdate: null,
     };
 
     private shutdown: boolean = false;
+
+    private simulatorPaused: boolean = false;
 
     private connection: Connection = null;
 
@@ -64,6 +81,16 @@ export class SimConnect {
     private frameDataLeft: ClientDataArea = null;
 
     private frameDataRight: ClientDataArea = null;
+
+    private simulatorStateEvent: SystemEvent = null;
+
+    private pauseStateEvent: SystemEvent = null;
+
+    private registerSystemEvents(): boolean {
+        this.simulatorStateEvent = new SystemEvent(this.connection, SystemEventId.SimulatorState, SystemEventType.Sim);
+        this.pauseStateEvent = new SystemEvent(this.connection, SystemEventId.PauseState, SystemEventType.PauseEX1);
+        return true;
+    }
 
     private registerEgpwcAircraftStatus(): boolean {
         this.egpwcAircraftStatus = new ClientDataArea(this.connection, ClientDataId.EnhancedGpwcAircraftStatus);
@@ -167,6 +194,12 @@ export class SimConnect {
             if (!this.receiver.requestClientData(this.egpwcAircraftStatus, ClientDataPeriod.OnSet, ClientDataRequest.Default)) {
                 this.logging.error('Unable to request aircraft status data');
             }
+            if (!this.receiver.subscribeSystemEvent(this.simulatorStateEvent)) {
+                this.logging.error('Unable to subscribe to the simulator states');
+            }
+            if (!this.receiver.subscribeSystemEvent(this.pauseStateEvent)) {
+                this.logging.error('Unable to subscribe to the pause states');
+            }
         }
     }
 
@@ -177,12 +210,14 @@ export class SimConnect {
         this.frameMetadataRight = null;
         this.frameDataLeft = null;
         this.frameDataRight = null;
+        this.simulatorStateEvent = null;
+        this.pauseStateEvent = null;
         this.connection.close();
     }
 
     private simConnectQuit(): void {
-        if (this.callbacks.connectionLost !== null) {
-            this.callbacks.connectionLost();
+        if (this.callbacks.reset !== null) {
+            this.callbacks.reset();
         }
 
         this.resetConnection();
@@ -251,12 +286,28 @@ export class SimConnect {
         }
     }
 
+    private simConnectSystemEvent(message: SystemEventMessage): void {
+        if (message.eventId === SystemEventId.SimulatorState) {
+            const sim = message.content as SystemEventSim;
+            if (sim.running === false && this.callbacks.reset !== null) {
+                this.callbacks.reset();
+            }
+        } else if (message.eventId === SystemEventId.PauseState) {
+            const pause = message.content as SystemEventPause;
+            if (pause.type !== SystemEventPauseType.Unpaused) {
+                if (this.callbacks.paused !== null) this.callbacks.paused();
+            } else if (this.callbacks.unpaused !== null) this.callbacks.unpaused();
+        } else {
+            this.logging.error(`Unknown system event ID: ${message.eventId}`);
+        }
+    }
+
     private connectToSim() {
         if (this.shutdown) return;
 
         this.connection = new Connection();
         if (this.connection.open(SimConnectClientName) === false) {
-            this.logging.error(`Connection failed: ${this.connection.lastError()} - Retry in 10 seconds`);
+            this.logging.error(`Connection to MSFS failed: ${this.connection.lastError()} - Retry in 10 seconds`);
             setTimeout(() => this.connectToSim(), 10000);
             return;
         }
@@ -266,6 +317,7 @@ export class SimConnect {
         this.receiver.addCallback('open', (message: OpenMessage) => this.simConnectOpen(message));
         this.receiver.addCallback('quit', () => this.simConnectQuit());
         this.receiver.addCallback('clientData', (message: ClientDataRequestMessage) => this.simConnectReceivedClientData(message));
+        this.receiver.addCallback('systemEvent', (message: SystemEventMessage) => this.simConnectSystemEvent(message));
         this.receiver.addCallback('exception', (message: ExceptionMessage) => this.simConnectException(message));
         this.receiver.addCallback('error', (message: ErrorMessage) => this.simConnectError(message));
         this.receiver.start();
@@ -295,7 +347,7 @@ export class SimConnect {
             return;
         }
 
-        if (!this.registerNavigationDisplayData()) {
+        if (!this.registerNavigationDisplayData() || !this.registerSystemEvents()) {
             this.receiver.stop();
             this.connection.close();
             setTimeout(() => this.connectToSim(), 10000);

--- a/apps/server/src/terrain/communication/simconnect.ts
+++ b/apps/server/src/terrain/communication/simconnect.ts
@@ -376,12 +376,20 @@ export class SimConnect {
         packed.writeUInt8(metadata.DisplayMode, 9);
         packed.writeUInt32LE(metadata.FrameByteCount, 10);
 
+        let resetConnection = false;
         if (side === 'L') {
             if (this.frameMetadataLeft.setData({ ThresholdData: packed.buffer }) === false) {
                 this.logging.error(`Could not send metadata: ${this.frameMetadataLeft.lastError()}`);
+                resetConnection = true;
             }
         } else if (this.frameMetadataRight.setData({ ThresholdData: packed.buffer }) === false) {
             this.logging.error(`Could not send metadata: ${this.frameMetadataRight.lastError()}`);
+            resetConnection = true;
+        }
+
+        if (resetConnection === true) {
+            this.logging.error('Resetting connection to MSFS due to transmission error');
+            this.simConnectQuit();
         }
     }
 
@@ -399,12 +407,21 @@ export class SimConnect {
             frame.copy(stream, 0, i * ClientDataMaxSize, i * ClientDataMaxSize + byteCount);
 
             // send the data
+            let resetConnection = false;
             if (side === 'L') {
                 if (this.frameDataLeft.setData({ FrameData: stream.buffer }) === false) {
                     this.logging.error(`Could not send frame data: ${this.frameDataLeft.lastError()}`);
+                    resetConnection = true;
                 }
             } else if (this.frameDataRight.setData({ FrameData: stream.buffer }) === false) {
                 this.logging.error(`Could not send frame data: ${this.frameDataRight.lastError()}`);
+                resetConnection = true;
+            }
+
+            if (resetConnection === true) {
+                this.logging.error('Resetting connection to MSFS due to transmission error');
+                this.simConnectQuit();
+                break;
             }
         }
     }

--- a/apps/server/src/terrain/communication/simconnect.ts
+++ b/apps/server/src/terrain/communication/simconnect.ts
@@ -66,7 +66,7 @@ export class SimConnect {
 
     private shutdown: boolean = false;
 
-    private simulatorPaused: boolean = false;
+    private showConnectionError: boolean = true;
 
     private connection: Connection = null;
 
@@ -307,8 +307,11 @@ export class SimConnect {
 
         this.connection = new Connection();
         if (this.connection.open(SimConnectClientName) === false) {
-            this.logging.error(`Connection to MSFS failed: ${this.connection.lastError()} - Retry in 10 seconds`);
+            if (this.showConnectionError === true) {
+                this.logging.error(`Connection to MSFS failed: ${this.connection.lastError()} - Retry every 10 seconds`);
+            }
             setTimeout(() => this.connectToSim(), 10000);
+            this.showConnectionError = false;
             return;
         }
 
@@ -351,7 +354,11 @@ export class SimConnect {
             this.receiver.stop();
             this.connection.close();
             setTimeout(() => this.connectToSim(), 10000);
+            return;
         }
+
+        this.logging.info('Connected to MSFS and established all communication channels');
+        this.showConnectionError = true;
     }
 
     constructor(private logging: Logger) {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"react-dom": "^17.0.0"
 	},
 	"dependencies": {
-		"@flybywiresim/msfs-nodejs": "^0.2.0",
+		"@flybywiresim/msfs-nodejs": "^0.3.0",
 		"@nestjs/axios": "^0.0.6",
 		"@nestjs/common": "^8.0.0",
 		"@nestjs/config": "^1.2.0",


### PR DESCRIPTION
This PR introduces system event handling of MSFS to check the current state and avoid sending data if the sim is not ready to receive it.