### PR TITLE
fix: show/hide behaviour for windows terminal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,13 @@
 	"packages": {
 		"": {
 			"name": "fbw-simbridge",
-			"version": "0.4.2",
+			"version": "0.4.4",
 			"license": "GPL-3.0-only",
 			"os": [
 				"win32"
 			],
 			"dependencies": {
-				"@flybywiresim/msfs-nodejs": "^0.2.0",
+				"@flybywiresim/msfs-nodejs": "^0.3.0",
 				"@nestjs/axios": "^0.0.6",
 				"@nestjs/common": "^8.0.0",
 				"@nestjs/config": "^1.2.0",
@@ -34,7 +34,7 @@
 				"mime-types": "^2.1.34",
 				"multicast-dns": "^7.2.5",
 				"nest-winston": "^1.6.2",
-				"node-hide-console-window": "^2.1.1",
+				"node-hide-console-window": "^2.2.0",
 				"open": "^8.4.0",
 				"pdf-to-printer": "^5.2.0",
 				"pdfjs-dist": "^2.13.216",
@@ -2347,9 +2347,9 @@
 			}
 		},
 		"node_modules/@flybywiresim/msfs-nodejs": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@flybywiresim/msfs-nodejs/-/msfs-nodejs-0.2.0.tgz",
-			"integrity": "sha512-BWeSsPtO9w2M1zTEaDrCp7Qq2eVhgf5BbrCPDvAXj72TN3ZOUs9Mn9IwV2GPpzYlzbhYJ46IqnFDWF1DjcxsKw==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@flybywiresim/msfs-nodejs/-/msfs-nodejs-0.3.0.tgz",
+			"integrity": "sha512-cijGPI0IDATb7icfDWC6wu1DoR0G8ehnYDYSKyMCngVBZ7ms7RUwIBWCdslMt8hJdjYSIlAAhF0SppGDL11fXQ==",
 			"dependencies": {
 				"node-addon-api": "^5.0.0"
 			}
@@ -12503,9 +12503,9 @@
 			}
 		},
 		"node_modules/node-hide-console-window": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/node-hide-console-window/-/node-hide-console-window-2.1.1.tgz",
-			"integrity": "sha512-6knDFNCPJhgbXF10xJWVJb4COe6pvr4pI6wX4B3g9owErZD7oltrqiZS6wtoAH81dZUZFe6ys+kZDpcsH9nfqw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/node-hide-console-window/-/node-hide-console-window-2.2.0.tgz",
+			"integrity": "sha512-CNLpd14IJbDQqzl6ryrpc4tjB2modRV+OvKekuu0KvLhqBj7ybmDWTXxHexG6LRrWW55Hfky/ZyZheh0xVXxDg==",
 			"hasInstallScript": true,
 			"os": [
 				"win32"
@@ -19605,9 +19605,9 @@
 			}
 		},
 		"@flybywiresim/msfs-nodejs": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@flybywiresim/msfs-nodejs/-/msfs-nodejs-0.2.0.tgz",
-			"integrity": "sha512-BWeSsPtO9w2M1zTEaDrCp7Qq2eVhgf5BbrCPDvAXj72TN3ZOUs9Mn9IwV2GPpzYlzbhYJ46IqnFDWF1DjcxsKw==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@flybywiresim/msfs-nodejs/-/msfs-nodejs-0.3.0.tgz",
+			"integrity": "sha512-cijGPI0IDATb7icfDWC6wu1DoR0G8ehnYDYSKyMCngVBZ7ms7RUwIBWCdslMt8hJdjYSIlAAhF0SppGDL11fXQ==",
 			"requires": {
 				"node-addon-api": "^5.0.0"
 			}
@@ -27419,9 +27419,9 @@
 			}
 		},
 		"node-hide-console-window": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/node-hide-console-window/-/node-hide-console-window-2.1.1.tgz",
-			"integrity": "sha512-6knDFNCPJhgbXF10xJWVJb4COe6pvr4pI6wX4B3g9owErZD7oltrqiZS6wtoAH81dZUZFe6ys+kZDpcsH9nfqw=="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/node-hide-console-window/-/node-hide-console-window-2.2.0.tgz",
+			"integrity": "sha512-CNLpd14IJbDQqzl6ryrpc4tjB2modRV+OvKekuu0KvLhqBj7ybmDWTXxHexG6LRrWW55Hfky/ZyZheh0xVXxDg=="
 		},
 		"node-int64": {
 			"version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"mime-types": "^2.1.34",
 		"multicast-dns": "^7.2.5",
 		"nest-winston": "^1.6.2",
-		"node-hide-console-window": "^2.1.1",
+		"node-hide-console-window": "^2.2.0",
 		"open": "^8.4.0",
 		"pdf-to-printer": "^5.2.0",
 		"pdfjs-dist": "^2.13.216",


### PR DESCRIPTION
Fixes show/hide behaviour when having Windows Terminal instead of Windows Console Host configured as the standard terminal application. See https://github.com/hetrodoo/node-hide-console-window/pull/8

<Details>
<summary>Before</summary>

https://github.com/flybywiresim/simbridge/assets/50082450/b0ae6a10-5734-430e-a1bd-c8460edf1500

Note the terminal application stays in the task bar, instead some inconsistent minimize/maximize action is executed with the current version of Windows Terminal

</details>

<details>
<summary>After</summary>

https://github.com/flybywiresim/simbridge/assets/50082450/f5bc6b6c-b63b-470e-8a8a-edb63a03d256

The terminal shows/hides from the task bar as intended.
</details>