### PR TITLE
feat: Support image conversion for PDF URLs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -55,7 +55,8 @@
 			{
 				"singleQuote": true,
 				"parser": "typescript",
-				"printWidth": 120
+				"printWidth": 120,
+				"endOfLine": "auto"
 			}
 		],
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install
 # Build all packages
 $ npm run build
 
-# Start server, to use interfaces you need to build them beforehand
+# Start server; some steps required the first time, see below
 $ npm run start
 
 # Wipe build/ and dist/ folders, build all packages, package to exe and copy dependencies/resources to build folder
@@ -33,6 +33,20 @@ $ npm run build:exec
 # Package to exe and copy dependencies/resources to build folder, without rebuilding
 $ npm run install:exec
 
+```
+
+## First time running with npm
+
+The server needs terrain data before it can run, so first do a full build:
+
+```bash
+$ npm run build:exec
+```
+
+This will build the terrain data in `build/terrain/`. This needs to be symlinked to the top level before running with npm:
+
+```bash
+mklink /J .\terrain .\build\terrain
 ```
 
 ## Documentation

--- a/apps/server/src/utilities/file.service.ts
+++ b/apps/server/src/utilities/file.service.ts
@@ -113,6 +113,11 @@ export class FileService {
     return getDocument({ data: retrievedFile }).promise.then((document) => document.numPages);
   }
 
+  async getNumberOfPdfPagesFromUrl(url: string): Promise<number> {
+    const doc = await this.getPdfFromUrl(url);
+    return doc.numPages;
+  }
+
   /**
    * Calling this function checks the safety of the supplied file path and throws an error if it deemed not safe against various potential attacks.
    * @param filePath
@@ -127,7 +132,18 @@ export class FileService {
     }
   }
 
-  async getConvertedPdfFileFromUrl(url: string, pageNumber: number, scale: number = 4): Promise<StreamableFile> {
+  async getPdfFromUrl(url: string): Promise<PDFDocumentProxy> {
+    if (this.pdfCache.has(url)) {
+      return this.pdfCache.get(url);
+    }
+
+    const resp = await fetch(url);
+    if (!resp.ok) {
+      throw new Error('encountered error retrieving PDF file');
+    }
+
+    const data = new Uint8Array(await resp.arrayBuffer());
+
     // Some PDFs need external cmaps.
     const CMAP_URL = `${join(getExecutablePath(), 'node_modules', 'pdfjs-dist', 'cmaps')}/`;
     const CMAP_PACKED = true;
@@ -135,33 +151,26 @@ export class FileService {
     // Where the standard fonts are located.
     const STANDARD_FONT_DATA_URL = `${join(getExecutablePath(), 'node_modules', 'pdfjs-dist', 'standard_fonts')}/`;
 
+    // Load the PDF file.
+    const pdfDocument = await getDocument({
+      data,
+      cMapUrl: CMAP_URL,
+      cMapPacked: CMAP_PACKED,
+      standardFontDataUrl: STANDARD_FONT_DATA_URL,
+    }).promise;
+
+    this.pdfCache.set(url, pdfDocument);
+    return pdfDocument;
+  }
+
+  async getConvertedPdfFileFromUrl(url: string, pageNumber: number, scale: number = 4): Promise<StreamableFile> {
     try {
       const pngKey = `${url};;${pageNumber};;${scale}`;
       if (this.pngCache.has(pngKey)) {
         return new StreamableFile(this.pngCache.get(pngKey));
       }
 
-      if (!this.pdfCache.has(url)) {
-        const resp = await fetch(url);
-        if (!resp.ok) {
-          throw new Error('encountered error retrieving PDF file');
-        }
-
-        const data = new Uint8Array(await resp.arrayBuffer());
-
-        // Load the PDF file.
-        const pdfDocument = await getDocument({
-          data,
-          cMapUrl: CMAP_URL,
-          cMapPacked: CMAP_PACKED,
-          standardFontDataUrl: STANDARD_FONT_DATA_URL,
-        }).promise;
-
-        this.pdfCache.set(url, pdfDocument);
-      }
-
-      const file = this.pdfCache.get(url);
-
+      const file = await this.getPdfFromUrl(url);
       const pngBuffer = await pdfToPng(file, pageNumber, scale);
 
       if (!this.pngCache.has(pngKey)) {

--- a/apps/server/src/utilities/utilities.controller.ts
+++ b/apps/server/src/utilities/utilities.controller.ts
@@ -59,6 +59,17 @@ export class UtilityController {
     return convertedPdfFile;
   }
 
+  @Get('pdf/fromUrl/numpages')
+  @ApiResponse({
+    status: 200,
+    description: 'Returns the number of pages in the pdf at the URL',
+    type: Number,
+  })
+  async getNumberOfPagesFromUrl(@Query('encodedUrl') encodedUrl: string): Promise<number> {
+    const url = decodeURIComponent(encodedUrl);
+    return this.fileService.getNumberOfPdfPagesFromUrl(url);
+  }
+
   @Get('pdf/list')
   @ApiResponse({
     status: 200,

--- a/apps/server/src/utilities/utilities.controller.ts
+++ b/apps/server/src/utilities/utilities.controller.ts
@@ -37,6 +37,28 @@ export class UtilityController {
     return convertedPdfFile;
   }
 
+  @Get('pdf/fromUrl')
+  @ApiResponse({
+    status: 200,
+    description: 'A streamed converted png image',
+    type: StreamableFile,
+  })
+  async getPdfFromUrl(
+    @Query('encodedUrl') encodedUrl: string,
+    @Query('pagenumber', ParseIntPipe) pagenumber: number,
+    @Response({ passthrough: true }) res,
+  ): Promise<StreamableFile> {
+    const url = decodeURIComponent(encodedUrl);
+    const convertedPdfFile = await this.fileService.getConvertedPdfFileFromUrl(`${url}`, pagenumber);
+
+    res.set({
+      'Content-Type': 'image/png',
+      'Content-Disposition': `attachment; filename=out-${pagenumber}.png`,
+    });
+
+    return convertedPdfFile;
+  }
+
   @Get('pdf/list')
   @ApiResponse({
     status: 200,


### PR DESCRIPTION
closes #110 
contributes to https://github.com/flybywiresim/aircraft/issues/5768

Remaining work:

- [x] Test multi-page PDFs

## Description

ChartFox provides some charts in PDF format. Since they can't be converted in the EFB itself, this service will allow support for those charts as long as there is a SimBridge connection.

I've mostly duplicated the existing functions for local files, but added `FromUrl` on the end. For the paths, I kept everything mostly the same, just under the `/fromUrl` subpath. It could probably be cleaned up in its current form, but it works in its current form.

## Proof this works

Get PDF image:

![image](https://github.com/flybywiresim/simbridge/assets/4079548/365a9f15-c844-4669-bf41-917d33fd94c2)

Get page count:

![image](https://github.com/flybywiresim/simbridge/assets/4079548/63691f40-9b7d-4b56-8bc6-a186fda31fea)

Get page count for multi-page PDF:

![image](https://github.com/flybywiresim/simbridge/assets/4079548/d8be389a-f143-4772-a637-246a43742e8a)

Get page > 1:

![image](https://github.com/flybywiresim/simbridge/assets/4079548/f5516df2-bed3-4640-be38-457f44e821c2)

