### PR TITLE
fix: printer parsing crashing on certain systems

### DIFF
--- a/apps/server/src/utilities/printer.service.ts
+++ b/apps/server/src/utilities/printer.service.ts
@@ -44,7 +44,7 @@ export class PrinterService {
       this.logger.warn('Printer disabled or null printerName');
       return null;
     } catch (error) {
-      this.logger.error('Error retrieving printers list', error);
+      this.logger.error(`Error retrieving printers list: ${error}`, error);
       return null;
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "nest-winston": "^1.6.2",
         "node-hide-console-window": "^2.2.0",
         "open": "^8.4.0",
-        "pdf-to-printer": "^5.2.0",
+        "pdf-to-printer": "5.3.0",
         "pdfjs-dist": "^2.13.216",
         "pdfkit": "^0.13.0",
         "react": "^17.0.0",
@@ -14686,9 +14686,9 @@
       }
     },
     "node_modules/pdf-to-printer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/pdf-to-printer/-/pdf-to-printer-5.6.0.tgz",
-      "integrity": "sha512-yPZoLWFjbjnHoYNVLU8fyoVA5wPMmT6U4+W/ip+sTDZdt5hwcVuQSVe96rrqRB0kEaKznNcLU7BXSo42R7AHVQ=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pdf-to-printer/-/pdf-to-printer-5.3.0.tgz",
+      "integrity": "sha512-st1pTOfks+vr+QpGe04x2XAaEaeYfinlOCUL5H/breP7C4Dwx0Z74i9Hcjv9Yljbns5IXoUb2wY7em3EQoZOpw=="
     },
     "node_modules/pdfjs-dist": {
       "version": "2.16.105",
@@ -30707,9 +30707,9 @@
       "dev": true
     },
     "pdf-to-printer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/pdf-to-printer/-/pdf-to-printer-5.6.0.tgz",
-      "integrity": "sha512-yPZoLWFjbjnHoYNVLU8fyoVA5wPMmT6U4+W/ip+sTDZdt5hwcVuQSVe96rrqRB0kEaKznNcLU7BXSo42R7AHVQ=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pdf-to-printer/-/pdf-to-printer-5.3.0.tgz",
+      "integrity": "sha512-st1pTOfks+vr+QpGe04x2XAaEaeYfinlOCUL5H/breP7C4Dwx0Z74i9Hcjv9Yljbns5IXoUb2wY7em3EQoZOpw=="
     },
     "pdfjs-dist": {
       "version": "2.16.105",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fbw-simbridge",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "The simbridge server for FBW addons for various tasks the addons themselves can't achieve",
   "author": "",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "nest-winston": "^1.6.2",
     "node-hide-console-window": "^2.2.0",
     "open": "^8.4.0",
-    "pdf-to-printer": "^5.2.0",
+    "pdf-to-printer": "5.3.0",
     "pdfjs-dist": "^2.13.216",
     "pdfkit": "^0.13.0",
     "react": "^17.0.0",


### PR DESCRIPTION
- Use the same version of pdf-to-printer (newer versions have an error in the validation of the output and crash) as the installer. 

- Improve logger for the printer service to print the actual error if no stacktrace is available.

Note: this is meant to be a quick fix, the package pdf-to-printer is archived currently, we might need to fork it or use another library in the future. Also the logging config should be looked at in the future as this error was not visible without printing it directly.