### PR TITLE
fix: add folder fallback to prevent app crash

### DIFF
--- a/apps/server/src/utilities/pathUtil.ts
+++ b/apps/server/src/utilities/pathUtil.ts
@@ -14,7 +14,7 @@ export const getSimbridgeDir = () => {
   try {
     return path.join(getPath('appdata'), 'FlyByWireSim', 'Simbridge');
   } catch (e) {
-    Logger.warn('Could not get AppData path via WinAPI. Giving up.', e);
+    Logger.error('Could not get AppData path via WinAPI. Giving up.', e);
   }
 };
 

--- a/apps/server/src/utilities/pathUtil.ts
+++ b/apps/server/src/utilities/pathUtil.ts
@@ -1,27 +1,21 @@
 import getPath from 'platform-folders';
 import * as path from 'path';
 import { Logger } from '@nestjs/common';
-import { homedir } from 'os';
-import { execFileSync } from 'child_process';
 
 export const getSimbridgeDir = () => {
   try {
     return path.join(getPath('documents'), 'FlyByWireSim', 'Simbridge');
   } catch (e) {
-    Logger.warn('Could not get documents path via WinAPI, trying alternate method', e);
+    Logger.warn(
+      'Could not get documents path via WinAPI, Windows Controlled Folder Access is likely blocking the app. Using AppData as fallback',
+      e,
+    );
   }
   try {
-    const output = execFileSync('Powershell.exe', ['-Command', `[System.Environment]::GetFolderPath('MyDocuments')`]);
-    const documents = output.toString().trim();
-    if (!documents) {
-      throw new Error('Path is empty');
-    }
-    return path.join(documents, 'FlyByWireSim', 'Simbridge');
+    return path.join(getPath('appdata'), 'FlyByWireSim', 'Simbridge');
   } catch (e) {
-    Logger.warn('Could not get documents path via Powershell, trying to use %USERPROFILE% method', e);
+    Logger.warn('Could not get AppData path via WinAPI. Giving up.', e);
   }
-
-  return path.join(homedir(), 'Documents', 'FlyByWireSim', 'Simbridge');
 };
 
 //@ts-expect-error pkg only defined when running as exe

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fbw-simbridge",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fbw-simbridge",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "GPL-3.0-only",
       "os": [
         "win32"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fbw-simbridge",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "The simbridge server for FBW addons for various tasks the addons themselves can't achieve",
   "author": "",
   "private": false,


### PR DESCRIPTION
If Windows Controlled Folder access is enabled, it will prevent simbridge from accessing the documents folder and the app will crash. Added a fallback to use the appdata directory, which is not protected by default.

Note: the old workaround via powershell was removed, as the reason for platform-folders to fail was Windows blocking it as well. So it's not needed anymore IMO.

Fixes #134 
Fixes #133
Fixes #130