### PR TITLE
fix: recover from GPU rendering errors instead of crashing SimBridge

### DIFF
--- a/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
@@ -644,8 +644,8 @@ export class NavigationDisplayRenderer {
       this.renderingData.finalFrame = new Uint8ClampedArray(fastFlatten(frame));
       this.renderingData.thresholdData = this.analyzeMetadata(metadata, cutOffAltitude);
     } catch (err) {
-      // GPU.js kernel creation/execution can throw (e.g. shader compile failure - see
-      // issues #82/#83). Skip this map cycle instead of crashing the terrain worker thread.
+      // GPU.js kernel creation/execution can throw (e.g. shader compile failure).
+      // Skip this map cycle instead of crashing the terrain worker thread.
       this.logging.error(`Navigation display map cycle failed, skipping: ${err}`);
       return;
     }

--- a/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
@@ -628,19 +628,27 @@ export class NavigationDisplayRenderer {
       return;
     }
 
-    const elevationMap = this.maphandler.createLocalElevationMap(this.configuration);
-    const histogram = this.createElevationHistogram(elevationMap);
-    const cutOffAltitude = this.calculateAbsoluteCutOffAltitude();
+    let cutOffAltitude: number;
+    try {
+      const elevationMap = this.maphandler.createLocalElevationMap(this.configuration);
+      const histogram = this.createElevationHistogram(elevationMap);
+      cutOffAltitude = this.calculateAbsoluteCutOffAltitude();
 
-    // create the final map
-    const renderingData = this.createNavigationDisplayMap(elevationMap, histogram, cutOffAltitude);
-    if (renderingData === null) return;
+      // create the final map
+      const renderingData = this.createNavigationDisplayMap(elevationMap, histogram, cutOffAltitude);
+      if (renderingData === null) return;
 
-    const frame = renderingData as number[][];
-    const metadata = frame.splice(frame.length - 1)[0];
+      const frame = renderingData as number[][];
+      const metadata = frame.splice(frame.length - 1)[0];
 
-    this.renderingData.finalFrame = new Uint8ClampedArray(fastFlatten(frame));
-    this.renderingData.thresholdData = this.analyzeMetadata(metadata, cutOffAltitude);
+      this.renderingData.finalFrame = new Uint8ClampedArray(fastFlatten(frame));
+      this.renderingData.thresholdData = this.analyzeMetadata(metadata, cutOffAltitude);
+    } catch (err) {
+      // GPU.js kernel creation/execution can throw (e.g. shader compile failure - see
+      // issues #82/#83). Skip this map cycle instead of crashing the terrain worker thread.
+      this.logging.error(`Navigation display map cycle failed, skipping: ${err}`);
+      return;
+    }
 
     if (!this.configuration.terrOnNd) {
       // metadata is used in the TERRONND WASM module to detect frame changes, so we still have to send it even though ND TERR would be disabled on the A380X
@@ -683,14 +691,26 @@ export class NavigationDisplayRenderer {
   public render(): boolean {
     let renderingDone = false;
 
-    // eslint-disable-next-line no-bitwise
-    if (
-      (this.aircraftStatus.navigationDisplayRenderingMode & TerrainRenderingMode.ScanlineMode) ===
-      TerrainRenderingMode.ScanlineMode
-    ) {
-      renderingDone = this.scanlineModeTransition();
-    } else {
-      renderingDone = this.arcModeTransition();
+    try {
+      // eslint-disable-next-line no-bitwise
+      if (
+        (this.aircraftStatus.navigationDisplayRenderingMode & TerrainRenderingMode.ScanlineMode) ===
+        TerrainRenderingMode.ScanlineMode
+      ) {
+        renderingDone = this.scanlineModeTransition();
+      } else {
+        renderingDone = this.arcModeTransition();
+      }
+    } catch (err) {
+      // GPU.js kernel creation/execution (e.g. a shader compile failure from a flaky GPU
+      // driver, or a transient context loss) can throw here. Left unguarded, this throws
+      // inside a setInterval callback in the terrain worker thread, which - since nothing
+      // else catches it - kills the whole worker thread and, without an 'error' handler on
+      // the Worker in terrain.service.ts, can crash the entire SimBridge process (issue #82).
+      // Log and skip this frame instead of taking the whole app down; the next rendering
+      // cycle gets a fresh chance to succeed rather than the app dying outright (issue #83).
+      this.logging.error(`Navigation display rendering failed, skipping frame: ${err}`);
+      renderingDone = true;
     }
 
     return renderingDone;

--- a/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
@@ -702,13 +702,9 @@ export class NavigationDisplayRenderer {
         renderingDone = this.arcModeTransition();
       }
     } catch (err) {
-      // GPU.js kernel creation/execution (e.g. a shader compile failure from a flaky GPU
-      // driver, or a transient context loss) can throw here. Left unguarded, this throws
-      // inside a setInterval callback in the terrain worker thread, which - since nothing
-      // else catches it - kills the whole worker thread and, without an 'error' handler on
-      // the Worker in terrain.service.ts, can crash the entire SimBridge process (issue #82).
+      // GPU.js kernel creation/execution can throw (e.g. a shader compile failure).
       // Log and skip this frame instead of taking the whole app down; the next rendering
-      // cycle gets a fresh chance to succeed rather than the app dying outright (issue #83).
+      // cycle gets a fresh chance to succeed rather than the app dying outright.
       this.logging.error(`Navigation display rendering failed, skipping frame: ${err}`);
       renderingDone = true;
     }

--- a/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
@@ -267,13 +267,14 @@ export class VerticalDisplayRenderer {
           this.renderingData.finalFrame,
         );
       }
-
-      // do not overwrite the last frame of the initialization
+      
+      // Use the completed frame as the baseline for the next transition.
       this.renderingData.lastFrame = this.renderingData.currentFrame;
-
+      
       return true;
+        
     } catch (err) {
-      // see navigationdisplayrenderer.ts render() for why this guard exists (issues #82/#83)
+      // Skip this failed frame and continue on the next render cycle.
       this.logging.error(`Vertical display rendering failed, skipping frame: ${err}`);
       return true;
     }

--- a/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
@@ -190,8 +190,8 @@ export class VerticalDisplayRenderer {
 
       this.renderingData.finalFrame = new Uint8ClampedArray(fastFlatten(verticaldisplay));
     } catch (err) {
-      // GPU.js kernel creation/execution can throw (e.g. shader compile failure - see
-      // issues #82/#83). Skip this map cycle instead of crashing the terrain worker thread.
+      // GPU.js kernel creation/execution can throw (e.g. shader compile failure).
+      // Skip this map cycle instead of crashing the terrain worker thread.
       this.logging.error(`Vertical display map cycle failed, skipping: ${err}`);
       return;
     }

--- a/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
@@ -164,7 +164,9 @@ export class VerticalDisplayRenderer {
 
     try {
       const profile = this.maphandler.createElevationProfile(this.elevationConfig, RenderingElevationProfileWidth);
-      if (profile === null) return;
+      if (profile === null) {
+        return;
+      }
 
       const greyAreaStartsAtX =
         this.elevationConfig.trackChangesSignificantlyAtDistance >= 0 && this.elevationConfig.fmsPathUsed

--- a/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
@@ -162,28 +162,35 @@ export class VerticalDisplayRenderer {
     this.displayConfig.mapWidth = RenderingElevationProfileWidth;
     this.displayConfig.mapHeight = RenderingElevationProfileHeight;
 
-    const profile = this.maphandler.createElevationProfile(this.elevationConfig, RenderingElevationProfileWidth);
-    if (profile === null) return;
+    try {
+      const profile = this.maphandler.createElevationProfile(this.elevationConfig, RenderingElevationProfileWidth);
+      if (profile === null) return;
 
-    const greyAreaStartsAtX =
-      this.elevationConfig.trackChangesSignificantlyAtDistance >= 0 && this.elevationConfig.fmsPathUsed
-        ? verticalDisplayDistanceToPixelX(
-            this.elevationConfig.trackChangesSignificantlyAtDistance,
-            this.elevationConfig.range,
-          )
-        : -1;
+      const greyAreaStartsAtX =
+        this.elevationConfig.trackChangesSignificantlyAtDistance >= 0 && this.elevationConfig.fmsPathUsed
+          ? verticalDisplayDistanceToPixelX(
+              this.elevationConfig.trackChangesSignificantlyAtDistance,
+              this.elevationConfig.range,
+            )
+          : -1;
 
-    const verticaldisplay = this.renderer(
-      profile,
-      this.displayConfig.minimumAltitude,
-      this.displayConfig.maximumAltitude,
-      greyAreaStartsAtX,
-    ) as number[][];
+      const verticaldisplay = this.renderer(
+        profile,
+        this.displayConfig.minimumAltitude,
+        this.displayConfig.maximumAltitude,
+        greyAreaStartsAtX,
+      ) as number[][];
 
-    // some GPU drivers require the flush call to release internal memory
-    if (GpuProcessingActive) this.renderer.context.flush();
+      // some GPU drivers require the flush call to release internal memory
+      if (GpuProcessingActive) this.renderer.context.flush();
 
-    this.renderingData.finalFrame = new Uint8ClampedArray(fastFlatten(verticaldisplay));
+      this.renderingData.finalFrame = new Uint8ClampedArray(fastFlatten(verticaldisplay));
+    } catch (err) {
+      // GPU.js kernel creation/execution can throw (e.g. shader compile failure - see
+      // issues #82/#83). Skip this map cycle instead of crashing the terrain worker thread.
+      this.logging.error(`Vertical display map cycle failed, skipping: ${err}`);
+      return;
+    }
 
     if (this.renderingData.lastFrame === null) {
       const timeSinceStart = currentTime - this.startupTime;
@@ -229,35 +236,41 @@ export class VerticalDisplayRenderer {
   }
 
   public render(): boolean {
-    // nothing to do here
-    if (this.renderingData.finalFrame === null) return true;
+    try {
+      // nothing to do here
+      if (this.renderingData.finalFrame === null) return true;
 
-    const horizontalStep = Math.round(
-      (RenderingElevationProfileWidth / RenderingMapTransitionDurationScanlineMode) * RenderingMapTransitionDeltaTime,
-    );
-    this.renderingData.currentTransitionBorder += horizontalStep;
-
-    if (this.renderingData.currentTransitionBorder < RenderingElevationProfileWidth) {
-      this.renderingData.currentFrame = this.transitionFrame(
-        this.renderingData.lastFrame,
-        this.renderingData.finalFrame,
+      const horizontalStep = Math.round(
+        (RenderingElevationProfileWidth / RenderingMapTransitionDurationScanlineMode) * RenderingMapTransitionDeltaTime,
       );
+      this.renderingData.currentTransitionBorder += horizontalStep;
 
-      return false;
+      if (this.renderingData.currentTransitionBorder < RenderingElevationProfileWidth) {
+        this.renderingData.currentFrame = this.transitionFrame(
+          this.renderingData.lastFrame,
+          this.renderingData.finalFrame,
+        );
+
+        return false;
+      }
+
+      // perform the last frame
+      if (this.renderingData.currentTransitionBorder + horizontalStep > RenderingElevationProfileWidth) {
+        this.renderingData.currentFrame = this.transitionFrame(
+          this.renderingData.lastFrame,
+          this.renderingData.finalFrame,
+        );
+      }
+
+      // do not overwrite the last frame of the initialization
+      this.renderingData.lastFrame = this.renderingData.currentFrame;
+
+      return true;
+    } catch (err) {
+      // see navigationdisplayrenderer.ts render() for why this guard exists (issues #82/#83)
+      this.logging.error(`Vertical display rendering failed, skipping frame: ${err}`);
+      return true;
     }
-
-    // perform the last frame
-    if (this.renderingData.currentTransitionBorder + horizontalStep > RenderingElevationProfileWidth) {
-      this.renderingData.currentFrame = this.transitionFrame(
-        this.renderingData.lastFrame,
-        this.renderingData.finalFrame,
-      );
-    }
-
-    // do not overwrite the last frame of the initialization
-    this.renderingData.lastFrame = this.renderingData.currentFrame;
-
-    return true;
   }
 
   public displayConfiguration(): VerticalDisplay {

--- a/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
@@ -184,7 +184,9 @@ export class VerticalDisplayRenderer {
       ) as number[][];
 
       // some GPU drivers require the flush call to release internal memory
-      if (GpuProcessingActive) this.renderer.context.flush();
+      if (GpuProcessingActive) {
+        this.renderer.context.flush();
+      }
 
       this.renderingData.finalFrame = new Uint8ClampedArray(fastFlatten(verticaldisplay));
     } catch (err) {

--- a/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/verticaldisplayrenderer.ts
@@ -242,7 +242,9 @@ export class VerticalDisplayRenderer {
   public render(): boolean {
     try {
       // nothing to do here
-      if (this.renderingData.finalFrame === null) return true;
+      if (this.renderingData.finalFrame === null) {
+        return true;
+      }
 
       const horizontalStep = Math.round(
         (RenderingElevationProfileWidth / RenderingMapTransitionDurationScanlineMode) * RenderingMapTransitionDeltaTime,

--- a/apps/server/src/terrain/terrain.service.ts
+++ b/apps/server/src/terrain/terrain.service.ts
@@ -39,12 +39,10 @@ export class TerrainService implements OnApplicationShutdown {
 
   private attachWorkerHandlers(worker: Worker): void {
     // Node.js Worker instances are EventEmitters: an uncaught exception inside the worker
-    // thread (e.g. a GPU.js shader compile failure - see issues #82/#83) is surfaced as an
-    // 'error' event. If no 'error' listener is attached, Node re-throws it on the MAIN
-    // thread, which crashes the entire SimBridge process (this is what issue #82 reports).
+    // thread is surfaced as an 'error' event. If no 'error' listener is attached, Node re-throws it
+    // on the MAIN thread, which crashes the entire SimBridge process.
     // Attaching a listener here prevents that crash; instead we log it and respawn the
-    // worker so terrain rendering recovers on its own instead of staying dead until the user
-    // notices and restarts SimBridge manually (issue #83).
+    // worker so terrain rendering recovers on its own.
     worker.on('error', (err) => {
       this.logger.error(`Terrain worker crashed: ${err?.stack ?? err}`);
       this.respawnAfterCrash();

--- a/apps/server/src/terrain/terrain.service.ts
+++ b/apps/server/src/terrain/terrain.service.ts
@@ -51,7 +51,9 @@ export class TerrainService implements OnApplicationShutdown {
     });
 
     worker.on('exit', (code) => {
-      if (this.shuttingDown) return;
+      if (this.shuttingDown) {
+        return;
+      }
       if (code !== 0) {
         this.logger.error(`Terrain worker exited unexpectedly with code ${code}`);
         this.respawnAfterCrash();

--- a/apps/server/src/terrain/terrain.service.ts
+++ b/apps/server/src/terrain/terrain.service.ts
@@ -87,7 +87,9 @@ export class TerrainService implements OnApplicationShutdown {
   }
 
   private respawnAfterCrash(): void {
-    if (this.shuttingDown) return;
+    if (this.shuttingDown) {
+      return;
+    }
 
     this.frameDataCallbacks = [];
     this.terrainWorker = null;

--- a/apps/server/src/terrain/terrain.service.ts
+++ b/apps/server/src/terrain/terrain.service.ts
@@ -23,9 +23,42 @@ export class TerrainService implements OnApplicationShutdown {
     data: { timestamp: number; frames: Uint8ClampedArray[]; thresholds: NavigationDisplayThresholdsDto },
   ) => boolean)[] = [];
 
+  // guards against a respawn storm if the worker keeps crashing immediately on startup
+  private restartCount = 0;
+
+  private shuttingDown = false;
+
   constructor() {
+    this.spawnWorker();
+  }
+
+  private spawnWorker(): void {
     this.terrainWorker = new Worker(path.resolve(__dirname, './processing/terrainworker.js'));
-    this.terrainWorker.on('message', (data: WorkerToMainThreadMessage) => {
+    this.attachWorkerHandlers(this.terrainWorker);
+  }
+
+  private attachWorkerHandlers(worker: Worker): void {
+    // Node.js Worker instances are EventEmitters: an uncaught exception inside the worker
+    // thread (e.g. a GPU.js shader compile failure - see issues #82/#83) is surfaced as an
+    // 'error' event. If no 'error' listener is attached, Node re-throws it on the MAIN
+    // thread, which crashes the entire SimBridge process (this is what issue #82 reports).
+    // Attaching a listener here prevents that crash; instead we log it and respawn the
+    // worker so terrain rendering recovers on its own instead of staying dead until the user
+    // notices and restarts SimBridge manually (issue #83).
+    worker.on('error', (err) => {
+      this.logger.error(`Terrain worker crashed: ${err?.stack ?? err}`);
+      this.respawnAfterCrash();
+    });
+
+    worker.on('exit', (code) => {
+      if (this.shuttingDown) return;
+      if (code !== 0) {
+        this.logger.error(`Terrain worker exited unexpectedly with code ${code}`);
+        this.respawnAfterCrash();
+      }
+    });
+
+    worker.on('message', (data: WorkerToMainThreadMessage) => {
       if (data.type === WorkerToMainThreadMessageTypes.FrameData) {
         const response = data.content as {
           side: DisplaySide;
@@ -53,8 +86,30 @@ export class TerrainService implements OnApplicationShutdown {
     });
   }
 
+  private respawnAfterCrash(): void {
+    if (this.shuttingDown) return;
+
+    this.frameDataCallbacks = [];
+    this.terrainWorker = null;
+
+    // avoid a tight respawn loop if the worker is crashing immediately on every startup
+    // (e.g. a persistently broken GPU driver) - cap restarts and back off
+    this.restartCount += 1;
+    if (this.restartCount > 5) {
+      this.logger.error('Terrain worker has crashed repeatedly, giving up on automatic restarts');
+      return;
+    }
+
+    const delayMs = Math.min(1000 * 2 ** (this.restartCount - 1), 30000);
+    this.logger.warn(`Restarting terrain worker in ${delayMs}ms (attempt ${this.restartCount})`);
+    setTimeout(() => {
+      if (!this.shuttingDown) this.spawnWorker();
+    }, delayMs);
+  }
+
   onApplicationShutdown(_signal?: string) {
     this.logger.log(`Destroying ${TerrainService.name}`);
+    this.shuttingDown = true;
     if (this.terrainWorker) {
       this.terrainWorker.postMessage({ type: MainToWorkerThreadMessageTypes.Shutdown });
       this.terrainWorker.terminate();

--- a/apps/server/src/terrain/terrain.service.ts
+++ b/apps/server/src/terrain/terrain.service.ts
@@ -103,7 +103,9 @@ export class TerrainService implements OnApplicationShutdown {
     const delayMs = Math.min(1000 * 2 ** (this.restartCount - 1), 30000);
     this.logger.warn(`Restarting terrain worker in ${delayMs}ms (attempt ${this.restartCount})`);
     setTimeout(() => {
-      if (!this.shuttingDown) this.spawnWorker();
+      if (!this.shuttingDown) {
+        this.spawnWorker();
+      }
     }, delayMs);
   }
 


### PR DESCRIPTION
Split out of #150 per maintainer request, to keep review/blame scoped to one fix per PR.

An uncaught GPU error inside the terrain worker's render loop kills the whole worker thread, which crashes the process (#82) or just silently stops rendering (#83). The worker now respawns on error, and render calls are wrapped so one bad frame doesn't take the loop down.

Fixes #82
Fixes #83

Tested against the packaged exe against a live MSFS 2024 session.