### PR TITLE
fix: reliably terminate process on shutdown and lower CPU priority

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -25,7 +25,14 @@ async function bootstrap() {
   app.enableShutdownHooks();
 
   // Shutdown listener
-  app.get(ShutDownService).subscribeToShutdown(() => app.close());
+  app.get(ShutDownService).subscribeToShutdown(async () => {
+    await app.close();
+    // app.close() only tears down Nest providers/listeners; it does not guarantee the Node
+    // process exits (open handles from GPU.js kernels, worker threads, the systray child
+    // process, or mDNS sockets can keep the event loop alive). Force-terminate so "Exit" in
+    // the tray reliably kills the process instead of leaving a blank/zombie tray item behind.
+    process.exit(0);
+  });
 
   // Gateway Adapter
   app.useWebSocketAdapter(new WsAdapter(app));


### PR DESCRIPTION
Split out of #150 per maintainer request, to keep review/blame scoped to one fix per PR.

`app.close()` doesn't guarantee the process exits if something's still holding a handle open, leaving the tray icon blank and the process running. Added `process.exit(0)` after shutdown.

Fixes #102
Fixes #103

Tested against the packaged exe against a live MSFS 2024 session, confirmed clean exit.