### PR TITLE
fix: retry MCDU update request when simulator connects after client

### DIFF
--- a/apps/mcdu/src/App.jsx
+++ b/apps/mcdu/src/App.jsx
@@ -92,6 +92,17 @@ const App = () => {
       const messageType = lastMessage.data.split(':')[0];
       if (messageType === 'update') {
         setContent(JSON.parse(lastMessage.data.substring(lastMessage.data.indexOf(':') + 1)).left);
+      } else if (lastMessage.data === 'mcduDisconnected') {
+        // simulator has disconnected - clear the last known screen instead of showing stale data
+        setContent((previous) => ({
+          ...previous,
+          lines: previous.lines.map((line) => line.map(() => '')),
+          scratchpad: '',
+          title: '',
+          titleLeft: '',
+          page: '',
+          arrows: [false, false, false, false],
+        }));
       }
     }
   }, [lastMessage]);

--- a/apps/mcdu/src/App.jsx
+++ b/apps/mcdu/src/App.jsx
@@ -92,6 +92,14 @@ const App = () => {
       const messageType = lastMessage.data.split(':')[0];
       if (messageType === 'update') {
         setContent(JSON.parse(lastMessage.data.substring(lastMessage.data.indexOf(':') + 1)).left);
+      } else if (lastMessage.data === 'mcduConnected') {
+        // The simulator side just (re-)connected to the gateway. `requestUpdate` is only sent
+        // once, when this browser tab's own websocket first reaches OPEN (see the effect
+        // above) - if the simulator connects/reconnects *after* that (e.g. SimBridge started
+        // before MSFS, or the sim add-on reloaded), that one-shot request was broadcast to
+        // nobody and is never retried, so the MCDU screen just stays blank forever (issue
+        // #147). Re-request the current state whenever we see the simulator (re)join.
+        sendMessage('requestUpdate');
       } else if (lastMessage.data === 'mcduDisconnected') {
         // simulator has disconnected - clear the last known screen instead of showing stale data
         setContent((previous) => ({

--- a/apps/mcdu/src/App.jsx
+++ b/apps/mcdu/src/App.jsx
@@ -97,8 +97,8 @@ const App = () => {
         // once, when this browser tab's own websocket first reaches OPEN (see the effect
         // above) - if the simulator connects/reconnects *after* that (e.g. SimBridge started
         // before MSFS, or the sim add-on reloaded), that one-shot request was broadcast to
-        // nobody and is never retried, so the MCDU screen just stays blank forever (issue
-        // #147). Re-request the current state whenever we see the simulator (re)join.
+        // nobody and is never retried, so the MCDU screen just stays blank forever.
+        // Re-request the current state whenever we see the simulator (re)join.
         sendMessage('requestUpdate');
       } else if (lastMessage.data === 'mcduDisconnected') {
         // simulator has disconnected - clear the last known screen instead of showing stale data

--- a/apps/server/src/interfaces/mcdu.gateway.ts
+++ b/apps/server/src/interfaces/mcdu.gateway.ts
@@ -1,6 +1,12 @@
 import { Inject, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
-import { OnGatewayConnection, OnGatewayInit, WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import {
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  OnGatewayInit,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
 import { Server, WebSocket } from 'ws';
 import { PrinterService } from '../utilities/printer.service';
 import serverConfig from '../config/server.config';
@@ -10,7 +16,7 @@ import { NetworkService } from '../utilities/network.service';
   cors: { origin: '*' },
   path: '/interfaces/v1/mcdu',
 })
-export class McduGateway implements OnGatewayInit, OnGatewayConnection {
+export class McduGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
   constructor(
     @Inject(serverConfig.KEY) private serverConf: ConfigType<typeof serverConfig>,
     private printerService: PrinterService,
@@ -21,10 +27,17 @@ export class McduGateway implements OnGatewayInit, OnGatewayConnection {
 
   @WebSocketServer() server: Server;
 
+  // tracks the client (if any) that has identified itself as the simulator, so we can tell
+  // remote MCDU displays when the simulator connection is actually gone (see issue #85 -
+  // without this, the browser just keeps showing the last received data forever)
+  private simulatorClient: WebSocket | undefined;
+
   async afterInit(server: Server) {
     this.server = server;
     this.logger.log('Remote MCDU websocket initialised');
-    this.logger.log(`Initialised websocket gateway on ws://${await this.networkService.getLocalIp(true)}:${this.serverConf.port}${server.path}`);
+    this.logger.log(
+      `Initialised websocket gateway on ws://${await this.networkService.getLocalIp(true)}:${this.serverConf.port}${server.path}`,
+    );
   }
 
   handleConnection(client: WebSocket) {
@@ -33,6 +46,7 @@ export class McduGateway implements OnGatewayInit, OnGatewayConnection {
       const messageString = message.toString();
       if (messageString === 'mcduConnected') {
         this.logger.log('Simulator connected');
+        this.simulatorClient = client;
       }
       this.server.clients.forEach((client) => {
         if (client.readyState === WebSocket.OPEN) {
@@ -44,5 +58,18 @@ export class McduGateway implements OnGatewayInit, OnGatewayConnection {
         this.printerService.print(lines);
       }
     });
+  }
+
+  handleDisconnect(client: WebSocket) {
+    this.logger.log('Client disconnected');
+    if (client === this.simulatorClient) {
+      this.logger.log('Simulator disconnected');
+      this.simulatorClient = undefined;
+      this.server.clients.forEach((remainingClient) => {
+        if (remainingClient.readyState === WebSocket.OPEN) {
+          remainingClient.send('mcduDisconnected');
+        }
+      });
+    }
   }
 }


### PR DESCRIPTION
Split out of #150 per maintainer request, to keep review/blame scoped to one fix per PR.

**Stacked on #153** — this branch includes that commit as its base because the two fixes sit right next to each other in the same websocket message handler and #153 landed first in the original history. The diff below currently shows both commits; once #153 merges, this PR will automatically shrink to just the retry-on-connect change.

The browser only requests an MCDU update once, when its own socket opens. If the simulator connects after that (e.g. SimBridge started before MSFS, or the sim add-on reloaded), that one-shot request goes nowhere and the MCDU screen stays blank forever. Now retries on simulator connect.

Fixes #147

Tested against the packaged exe against a live MSFS 2024 session.