### PR TITLE
fix: use layout-aware key for physical CDU keyboard input

### DIFF
--- a/apps/mcdu/src/McduKeyboardEvents.js
+++ b/apps/mcdu/src/McduKeyboardEvents.js
@@ -38,10 +38,9 @@ export class McduKeyboardEvents {
       const fn = parseInt(keyEvent.code.replace('F', ''));
       return fn <= 6 ? `L${fn}` : `R${fn - 6}`;
     }
-
-    // match a-z; use keyEvent.key (respects the active keyboard layout, e.g. QWERTZ)
-    // instead of keyEvent.code (physical key position) to avoid letters like Y/Z being swapped
-    if (keyEvent.code.match(/Key[A-Z]/) && /^[a-zA-Z]$/.test(keyEvent.key)) {
+    
+    // Match a-z using keyEvent.key to respect the active keyboard layout (e.g. QWERTZ)
+    if (/^[a-zA-Z]$/.test(keyEvent.key)) {
       return keyEvent.key.toLocaleUpperCase();
     }
 

--- a/apps/mcdu/src/McduKeyboardEvents.js
+++ b/apps/mcdu/src/McduKeyboardEvents.js
@@ -39,9 +39,10 @@ export class McduKeyboardEvents {
       return fn <= 6 ? `L${fn}` : `R${fn - 6}`;
     }
 
-    // match a-z
-    if (keyEvent.code.match(/Key[A-Z]/)) {
-      return keyEvent.code.replace('Key', '').toLocaleUpperCase();
+    // match a-z; use keyEvent.key (respects the active keyboard layout, e.g. QWERTZ)
+    // instead of keyEvent.code (physical key position) to avoid letters like Y/Z being swapped
+    if (keyEvent.code.match(/Key[A-Z]/) && /^[a-zA-Z]$/.test(keyEvent.key)) {
+      return keyEvent.key.toLocaleUpperCase();
     }
 
     // match 0-9


### PR DESCRIPTION
Split out of #150 per maintainer request, to keep review/blame scoped to one fix per PR.

Was reading physical key position instead of the actual character, which swaps Y/Z on non-US keyboard layouts (e.g. QWERTZ). Now reads the layout-aware character.

Fixes #113

Tested against the packaged exe against a live MSFS 2024 session.