### PR TITLE
fix: make alternate optional in company route validation DTO

### DIFF
--- a/apps/server/src/coRoute/dto/coroute.dto.ts
+++ b/apps/server/src/coRoute/dto/coroute.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDefined, ValidateNested } from 'class-validator';
+import { IsDefined, IsOptional, ValidateNested } from 'class-validator';
 import { Navlog } from './navlog.dto';
 import { General } from './general.dto';
 import { Airport } from './airport.dto';
@@ -19,10 +19,13 @@ export class CoRouteDto {
   @IsDefined()
   destination: Airport;
 
-  @ApiProperty({ description: 'The alternate airport dto' })
+  // Not every company route has an alternate defined - previously this was required, so any
+  // route without one failed validation with "nested property alternate must be either object
+  // or array" and could not be loaded at all (issue #112). Make it optional instead.
+  @ApiProperty({ description: 'The alternate airport dto', required: false })
   @ValidateNested()
-  @IsDefined()
-  alternate: Airport;
+  @IsOptional()
+  alternate?: Airport;
 
   @ApiProperty({ description: 'General information' })
   @ValidateNested()

--- a/apps/server/src/coRoute/dto/coroute.dto.ts
+++ b/apps/server/src/coRoute/dto/coroute.dto.ts
@@ -19,9 +19,6 @@ export class CoRouteDto {
   @IsDefined()
   destination: Airport;
 
-  // Not every company route has an alternate defined - previously this was required, so any
-  // route without one failed validation with "nested property alternate must be either object
-  // or array" and could not be loaded at all (issue #112). Make it optional instead.
   @ApiProperty({ description: 'The alternate airport dto', required: false })
   @ValidateNested()
   @IsOptional()


### PR DESCRIPTION
Split out of #150 per maintainer request, to keep review/blame scoped to one fix per PR.

`alternate` was a required field in the company route validation DTO, so routes filed without an alternate were rejected outright. Made it optional.

Fixes #112

Tested against the packaged exe against a live MSFS 2024 session.