### PR TITLE
refactor: cache terrain sweep angle mask and reduce PNG encode cost

### DIFF
--- a/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
@@ -89,11 +89,10 @@ export class NavigationDisplayRenderer {
 
   private aircraftStatus: AircraftStatus = null;
 
-  // Per-pixel angle (degrees) from the display's bottom-center, used by the arc-mode sweep
-  // transition. This only depends on mapWidth/mapHeight, which change rarely (display config
-  // changes), so it is computed once and reused instead of recomputing sqrt/acos for every
-  // pixel on every 40ms transition frame - that recompute was a significant, avoidable CPU
-  // cost (up to ~370k trig calls per frame) that could contend with MSFS for CPU time.
+  /**
+   * Cached per-pixel angles from the display's bottom-center, indexed by pixel.
+   * Rebuilt only when the display dimensions change.
+   */
   private angleMapCache: { width: number; height: number; angles: Float32Array } | null = null;
 
   private renderingData: {
@@ -453,6 +452,7 @@ export class NavigationDisplayRenderer {
       return this.angleMapCache.angles;
     }
 
+    // Compute the angle for every pixel once. The result depends only on the map dimensions, so it can be reused until the dimensions change.
     const angles = new Float32Array(width * height);
     let arrayIndex = 0;
     for (let y = 0; y < height; ++y) {

--- a/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
+++ b/apps/server/src/terrain/processing/navigationdisplayrenderer.ts
@@ -89,6 +89,13 @@ export class NavigationDisplayRenderer {
 
   private aircraftStatus: AircraftStatus = null;
 
+  // Per-pixel angle (degrees) from the display's bottom-center, used by the arc-mode sweep
+  // transition. This only depends on mapWidth/mapHeight, which change rarely (display config
+  // changes), so it is computed once and reused instead of recomputing sqrt/acos for every
+  // pixel on every 40ms transition frame - that recompute was a significant, avoidable CPU
+  // cost (up to ~370k trig calls per frame) that could contend with MSFS for CPU time.
+  private angleMapCache: { width: number; height: number; angles: Float32Array } | null = null;
+
   private renderingData: {
     startTransitionBorder: number;
     currentTransitionBorder: number;
@@ -439,6 +446,27 @@ export class NavigationDisplayRenderer {
     return terrainmap;
   }
 
+  private getAngleMap(): Float32Array {
+    const { mapWidth: width, mapHeight: height } = this.configuration;
+
+    if (this.angleMapCache !== null && this.angleMapCache.width === width && this.angleMapCache.height === height) {
+      return this.angleMapCache.angles;
+    }
+
+    const angles = new Float32Array(width * height);
+    let arrayIndex = 0;
+    for (let y = 0; y < height; ++y) {
+      for (let x = 0; x < width; ++x) {
+        const distance = Math.sqrt((x - width / 2) ** 2 + (height - y) ** 2);
+        angles[arrayIndex] = distance === 0 ? 0 : Math.acos((height - y) / distance) * (180.0 / Math.PI);
+        arrayIndex++;
+      }
+    }
+
+    this.angleMapCache = { width, height, angles };
+    return angles;
+  }
+
   private arcModeTransitionFrame(
     oldFrame: Uint8ClampedArray,
     newFrame: Uint8ClampedArray,
@@ -457,22 +485,15 @@ export class NavigationDisplayRenderer {
     destination.fill(328708);
     const oldSource = oldFrame !== null ? new Uint32Array(oldFrame.buffer) : null;
     const newSource = new Uint32Array(newFrame.buffer);
+    const angleMap = this.getAngleMap();
 
-    let arrayIndex = 0;
-    for (let y = 0; y < this.configuration.mapHeight; ++y) {
-      for (let x = 0; x < this.configuration.mapWidth; ++x) {
-        const distance = Math.sqrt(
-          (x - this.configuration.mapWidth / 2) ** 2 + (this.configuration.mapHeight - y) ** 2,
-        );
-        const angle = Math.acos((this.configuration.mapHeight - y) / distance) * (180.0 / Math.PI);
+    for (let arrayIndex = 0; arrayIndex < angleMap.length; ++arrayIndex) {
+      const angle = angleMap[arrayIndex];
 
-        if (startAngle <= angle && angle <= endAngle) {
-          destination[arrayIndex] = newSource[arrayIndex];
-        } else if (oldSource !== null) {
-          destination[arrayIndex] = oldSource[arrayIndex];
-        }
-
-        arrayIndex++;
+      if (startAngle <= angle && angle <= endAngle) {
+        destination[arrayIndex] = newSource[arrayIndex];
+      } else if (oldSource !== null) {
+        destination[arrayIndex] = oldSource[arrayIndex];
       }
     }
 

--- a/apps/server/src/terrain/processing/terrainworker.ts
+++ b/apps/server/src/terrain/processing/terrainworker.ts
@@ -545,7 +545,12 @@ class TerrainWorker {
             channels: RenderingColorChannelCount,
           },
         })
-          .png()
+          // This buffer goes straight over local IPC to SimConnect and is immediately
+          // consumed - it's never stored or transmitted over a network, so there is no
+          // reason to pay for tight zlib compression on every ~40ms transition frame.
+          // Lowest compression level trades a larger (still tiny, in-memory) buffer for
+          // significantly less CPU time per frame.
+          .png({ compressionLevel: 1, adaptiveFiltering: false })
           .toBuffer()
           .then((buffer) => {
             const displayData = this.displayRendering[side].navigationDisplay.displayData();


### PR DESCRIPTION
Split out of #150 per maintainer request, to keep review/blame scoped to one fix per PR.

Found while investigating the stutter reports bundled in #150, not tied to a filed issue. A per-pixel trig calc was being redone every 40ms during terrain transitions for values that don't change frame to frame, and PNG compression on terrain frames was set way higher than needed for data that's just going over local IPC. Cached the angle mask and lowered the PNG compression cost.

No behavior/output change — same terrain image, just cheaper to produce.

Tested against the packaged exe against a live MSFS 2024 session, watched for stutter during terrain transitions.